### PR TITLE
Add Markdown .md files to the default list of documents for RAG

### DIFF
--- a/ChatRTX_APIs/ChatRTX/chatrtx_rag.py
+++ b/ChatRTX_APIs/ChatRTX/chatrtx_rag.py
@@ -225,7 +225,7 @@ class ChatRTXRag:
                 file_metadata = lambda x: {"filename": x}
                 documents = SimpleDirectoryReader(folder_path, file_metadata=file_metadata,
                                                   recursive=True,
-                                                  required_exts=[".pdf", ".doc", ".docx", ".txt", ".xml"]).load_data()
+                                                  required_exts=[".pdf", ".doc", ".docx", ".txt", ".xml", ".md"]).load_data()
             else:
                 self._logger.info("No files found in the directory. Initializing an empty index.")
                 documents = []


### PR DESCRIPTION
Add .md extension to files that are read for RAG.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/NVIDIA/ChatRTX/pull/117?shareId=a5b1b57a-0d64-4af6-b8ce-087919d1697f).